### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/roch_follower/src/follower.cpp
+++ b/roch_follower/src/follower.cpp
@@ -314,6 +314,6 @@ private:
   ros::Publisher bboxpub_;
 };
 
-PLUGINLIB_DECLARE_CLASS(roch_follower, RochFollower, roch_follower::RochFollower, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(roch_follower::RochFollower, nodelet::Nodelet)
 
 }


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions